### PR TITLE
umami: rm data-domain to fix tracking issue

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,7 +21,6 @@
   <script
   async
   defer
-  data-domains="slides.silviacanelon.com"
   data-website-id="4858c440-53e0-42a9-a5dd-75152398ea14"
   data-do-not-track="true"
   src="https://silvia.up.railway.app/umami.js"></script>


### PR DESCRIPTION
Umami was not picking up any visits so I'm trying to see if removing the `data-domain` field in the script will do anything